### PR TITLE
VoiceOver support

### DIFF
--- a/Example/Sources/BulletinDataSource.swift
+++ b/Example/Sources/BulletinDataSource.swift
@@ -29,6 +29,7 @@ enum BulletinDataSource {
 
         let page = FeedbackPageBulletinItem(title: "Welcome to Instanimal")
         page.image = #imageLiteral(resourceName: "RoundedIcon")
+        page.imageAccessibilityLabel = "😻"
 
         page.descriptionText = "Discover curated images of the best pets in the world."
         page.actionButtonTitle = "Configure"
@@ -59,6 +60,7 @@ enum BulletinDataSource {
 
         let page = FeedbackPageBulletinItem(title: "Push Notifications")
         page.image = #imageLiteral(resourceName: "NotificationPrompt")
+        page.imageAccessibilityLabel = "Notifications Icon"
 
         page.descriptionText = "Receive push notifications when new photos of pets are available."
         page.actionButtonTitle = "Subscribe"
@@ -95,6 +97,7 @@ enum BulletinDataSource {
 
         let page = FeedbackPageBulletinItem(title: "Customize Feed")
         page.image = #imageLiteral(resourceName: "LocationPrompt")
+        page.imageAccessibilityLabel = "Location Icon"
 
         page.descriptionText = "We can use your location to customize the feed. This data will be sent to our servers anonymously. You can update your choice later in the app settings."
         page.actionButtonTitle = "Send location data"
@@ -141,6 +144,7 @@ enum BulletinDataSource {
 
         let page = PageBulletinItem(title: "Setup Completed")
         page.image = #imageLiteral(resourceName: "IntroCompletion")
+        page.imageAccessibilityLabel = "Checkmark"
         page.interfaceFactory.tintColor = #colorLiteral(red: 0.2941176471, green: 0.8509803922, blue: 0.3921568627, alpha: 1)
         page.interfaceFactory.actionButtonTitleColor = .white
 

--- a/Sources/BulletinInterfaceFactory.swift
+++ b/Sources/BulletinInterfaceFactory.swift
@@ -62,6 +62,7 @@ public class BulletinInterfaceFactory {
         let titleLabel = UILabel()
         titleLabel.textAlignment = .center
         titleLabel.textColor = titleTextColor
+        titleLabel.accessibilityTraits |= UIAccessibilityTraitHeader
         titleLabel.numberOfLines = 1
         titleLabel.adjustsFontSizeToFitWidth = true
 

--- a/Sources/BulletinManager.swift
+++ b/Sources/BulletinManager.swift
@@ -278,6 +278,7 @@ public final class BulletinManager: NSObject, UIViewControllerTransitioningDeleg
                         self.viewController.contentStackView.removeArrangedSubview(arrangedSubview)
                     }
 
+                    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, newArrangedSubviews.first)
                 }
 
             }

--- a/Sources/BulletinViewController.swift
+++ b/Sources/BulletinViewController.swift
@@ -176,28 +176,34 @@ final class BulletinViewController: UIViewController {
     override func viewSafeAreaInsetsDidChange() {
         containerBottomConstraint.constant = bottomSpacingForCurrentLayout()
     }
+    
+    /// dismisses the presnted BulletinViewController if isDissmisable is set to true
+    @discardableResult
+    private func dismissIfPossible() -> Bool {
+    
+        guard isDismissable else {
+            return false
+        }
+    
+        manager?.dismissBulletin(animated: true)
+        return true
+
+    }
 
     // MARK: - Touch Events
 
     @objc private func handleTap(recognizer: UITapGestureRecognizer) {
 
-        guard isDismissable else {
-            return
-        }
-
-        manager?.dismissBulletin(animated: true)
-
+        dismissIfPossible()
+        
     }
     
     // MARK: - Accessibility
     
     override func accessibilityPerformEscape() -> Bool {
-        guard isDismissable else {
-            return false
-        }
+    
+        return dismissIfPossible()
         
-        manager?.dismissBulletin(animated: true)
-        return true
     }
 
 }

--- a/Sources/BulletinViewController.swift
+++ b/Sources/BulletinViewController.swift
@@ -188,5 +188,16 @@ final class BulletinViewController: UIViewController {
         manager?.dismissBulletin(animated: true)
 
     }
+    
+    // MARK: - Accessibility
+    
+    override func accessibilityPerformEscape() -> Bool {
+        guard isDismissable else {
+            return false
+        }
+        
+        manager?.dismissBulletin(animated: true)
+        return true
+    }
 
 }

--- a/Sources/BulletinViewController.swift
+++ b/Sources/BulletinViewController.swift
@@ -53,6 +53,7 @@ final class BulletinViewController: UIViewController {
         view.addGestureRecognizer(recognizer)
 
         contentView.translatesAutoresizingMaskIntoConstraints = false
+        contentView.accessibilityViewIsModal = true
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
 
         view.addSubview(contentView)

--- a/Sources/PageBulletinItem.swift
+++ b/Sources/PageBulletinItem.swift
@@ -35,6 +35,9 @@ open class PageBulletinItem: BulletinItem {
 
     /// An image to display below the title. Should be less than or equal to 128x128px.
     public var image: UIImage?
+    
+    /// An accessibility label which gets announced to VoiceOver users if the image gets focused.
+    public var imageAccessibilityLabel: String?
 
     /// A description text to display below the image.
     public var descriptionText: String?
@@ -138,6 +141,11 @@ open class PageBulletinItem: BulletinItem {
             imageView.image = image
             imageView.contentMode = .scaleAspectFit
             imageView.heightAnchor.constraint(lessThanOrEqualToConstant: 128).isActive = true
+            
+            if let imageAccessibilityLabel = imageAccessibilityLabel {
+                imageView.isAccessibilityElement = true
+                imageView.accessibilityLabel = imageAccessibilityLabel
+            }
 
             arrangedSubviews.append(imageView)
 


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
The current implementation isn't really usable for users that rely on assistive technologies especially with VoiceOver. Additionally, there is currently no way for developer that are using this framework to make their implementations accessible. This PR aims to provide a usable VoiceOver support per default and additionally provides public apis for developers to create a better experience. 

I tested my changes on my device (iPhone 6, iOS 11.02) with VoiceOver and Switch Control enabled.

### Description
Images are currently not accessible at all for VoiceOver users. I introduced a new variable `imageAccessibilityLabel` to PageBulletinItem to enable developers to add a description to their images. Images without description stay hidden for VoiceOver users.

Tapping on empty areas isn't easy or impossible for visually impaired users. Therefore, I added support for the escape gesture (swiping a Z with two fingers) for VoiceOver users and the escape button for Switch Control users if the current BulletinItem `isDismissable`.

As this projects only uses a single ViewController for different items and doesn't uses a UINavigationController, the assistive technologies doesn't get notified that the screen and their content changes. Therefore, I added `                    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, newArrangedSubviews.first)` which notifies the system to recalculate the accessibility tree and additionally moves the focus back to the first element of the new item instead of keeping the focus on the tapped button.

I also added the `UIAccessibiltyTraitHeader` to titleLabel to support VoiceOvers header rotor. 

`accessibilityViewIsModal` makes sure that VoiceOver ignores all the elements behind the current BulletinBoard which would otherwise still be accessible via VoiceOver. 