### PR TITLE
Keyboard logic

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		55DADE851F7E592F001B11A2 /* CollectionUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DADE841F7E592F001B11A2 /* CollectionUtilities.swift */; };
 		55DADE911F7ED65E001B11A2 /* BulletinBoard.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55DADE901F7ED65E001B11A2 /* BulletinBoard.framework */; };
 		55DADE921F7ED65E001B11A2 /* BulletinBoard.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 55DADE901F7ED65E001B11A2 /* BulletinBoard.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		652A87ED1FA24C8B006CDCF6 /* TextFieldBulletinPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 652A87EC1FA24C8B006CDCF6 /* TextFieldBulletinPage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -53,6 +54,7 @@
 		55DADE821F7E4204001B11A2 /* PermissionsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsManager.swift; sourceTree = "<group>"; };
 		55DADE841F7E592F001B11A2 /* CollectionUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionUtilities.swift; sourceTree = "<group>"; };
 		55DADE901F7ED65E001B11A2 /* BulletinBoard.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BulletinBoard.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		652A87EC1FA24C8B006CDCF6 /* TextFieldBulletinPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldBulletinPage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +118,7 @@
 				55DADE771F7D8B29001B11A2 /* PetSelectorBulletinPage.swift */,
 				55DADE801F7E3C0B001B11A2 /* FeedbackPageBulletinItem.swift */,
 				5506756A1F90ADEF00874D8B /* BackgroundStyles.swift */,
+				652A87EC1FA24C8B006CDCF6 /* TextFieldBulletinPage.swift */,
 			);
 			name = Bulletin;
 			sourceTree = "<group>";
@@ -202,6 +205,7 @@
 				558A12451F7D7865005EC97C /* AppDelegate.swift in Sources */,
 				55DADE761F7D7AEA001B11A2 /* BulletinDataSource.swift in Sources */,
 				55DADE811F7E3C0B001B11A2 /* FeedbackPageBulletinItem.swift in Sources */,
+				652A87ED1FA24C8B006CDCF6 /* TextFieldBulletinPage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Sources/BulletinDataSource.swift
+++ b/Example/Sources/BulletinDataSource.swift
@@ -22,7 +22,7 @@ enum BulletinDataSource {
      * This creates a `FeedbackPageBulletinItem` with: a title, an image, a description text and
      * and action button.
      *
-     * The action button presents the next item (the notification page).
+     * The action button presents the next item (the textfield page).
      */
 
     static func makeIntroPage() -> FeedbackPageBulletinItem {
@@ -40,10 +40,28 @@ enum BulletinDataSource {
             item.displayNextItem()
         }
 
-        page.nextItem = makeNotitificationsPage()
+        page.nextItem = makeTextFieldPage()
 
         return page
 
+    }
+
+    /**
+     * Create the textfield page.
+     *
+     * This creates a `TextFieldBulletinPage` with: a title, an error label and a textfield.
+     *
+     * The keyboard return button presents the next item (the notification page).
+     */
+    static func makeTextFieldPage() -> TextFieldBulletinPage {
+        let page = TextFieldBulletinPage()
+        page.nextItem = makeNotitificationsPage()
+
+        page.actionHandler = { item in
+            item.displayNextItem()
+        }
+
+        return page
     }
 
     /**
@@ -66,7 +84,7 @@ enum BulletinDataSource {
         page.actionButtonTitle = "Subscribe"
         page.alternativeButtonTitle = "Not now"
 
-        page.isDismissable = false
+        page.isDismissable = true
 
         page.actionHandler = { item in
             PermissionsManager.shared.requestLocalNotifications()

--- a/Example/Sources/TextFieldBulletinPage.swift
+++ b/Example/Sources/TextFieldBulletinPage.swift
@@ -1,0 +1,80 @@
+//
+//  TextFieldBulletinPage.swift
+//  Example
+//
+//  Created by Junaid Younus on 26/10/2017.
+//  Copyright © 2017 Alexis Aubry. All rights reserved.
+//
+
+import UIKit
+import BulletinBoard
+
+class TextFieldBulletinPage: NSObject, BulletinItem {
+    var manager: BulletinManager?
+    var isDismissable: Bool = true
+    var dismissalHandler: ((BulletinItem) -> Void)?
+    var nextItem: BulletinItem?
+
+    public let interfaceFactory = BulletinInterfaceFactory()
+    public var actionHandler: ((BulletinItem) -> Void)? = nil
+
+    fileprivate var errorLabel: UILabel?
+    fileprivate var textField: UITextField?
+
+    func tearDown() {
+        errorLabel = nil
+        textField = nil
+    }
+
+    func makeArrangedSubviews() -> [UIView] {
+        var arrangedSubviews = [UIView]()
+
+        let titleLabel = interfaceFactory.makeTitleLabel(reading: "TextField example")
+        arrangedSubviews.append(titleLabel)
+
+        errorLabel = interfaceFactory.makeDescriptionLabel(isCompact: true)
+        errorLabel!.text = ""
+        errorLabel!.textColor = .red
+        arrangedSubviews.append(errorLabel!)
+
+        textField = UITextField()
+        textField!.delegate = self
+        textField!.borderStyle = .roundedRect
+        textField!.returnKeyType = .done
+        arrangedSubviews.append(textField!)
+
+        // since there isn't a method similar to "viewDidAppear" for BulletinItems,
+        // we're using a workaround open the keyboard after a certain amount of time has elapsed
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) { [weak self] in
+            self?.textField?.becomeFirstResponder()
+        }
+
+        return arrangedSubviews
+    }
+}
+
+extension TextFieldBulletinPage: UITextFieldDelegate {
+    func isInputValid(text: String?) -> Bool {
+        // some logic here to verify input
+
+        if text != nil && !text!.isEmpty {
+            // return true to continue to the next bulletin item
+            return true
+        }
+
+        return false
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if isInputValid(text: textField.text) {
+            textField.resignFirstResponder()
+            actionHandler?(self)
+            return true
+
+        } else {
+            errorLabel?.text = "You must enter some text to continue."
+            textField.backgroundColor = .red
+            return false
+        }
+    }
+}


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I updated the project to support UITextFields/UITextViews. This PR will cause the contentView's bottom constraint to animate based on the keyboard's height. When the keyboard is dismissed, it will animate the view back down to the initial position again.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/alexaubry/BulletinBoard/issues/11

<!--- Please describe how you tested your changes. --->
I've tested this on the iPhone 5, iPhone 8 and iPhone X simulators. I updated the sample project and included a new "TextFieldBulletinPage" class to demo this behaviour. 

### Description
<!--- Describe your changes in detail. -->
See above. I reused some code from one of my existing projects and adapted it for this lib. This should now allow you to present the keyboard without having it block the bulletin view. 