### PR TITLE
Fix dismiss tap background gesture

### DIFF
--- a/Sources/BulletinViewController.swift
+++ b/Sources/BulletinViewController.swift
@@ -62,6 +62,7 @@ final class BulletinViewController: UIViewController, UIGestureRecognizerDelegat
         view.backgroundColor = .clear
 
         let recognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap(recognizer:)))
+        recognizer.delegate = self
         view.addGestureRecognizer(recognizer)
 
         contentView.accessibilityViewIsModal = true
@@ -147,6 +148,16 @@ final class BulletinViewController: UIViewController, UIGestureRecognizerDelegat
         contentView.backgroundColor = #colorLiteral(red: 0.9921568627, green: 1, blue: 1, alpha: 1)
         setUpLayout(with: traitCollection)
 
+    }
+    
+    // MARK: - Gesture Recognizer
+    
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        if touch.view?.isDescendant(of: contentView) == true {
+            return false
+        }
+        
+        return true
     }
 
     // MARK: - Layout


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change stops tapping the content view background from dismissing the card to match the documented feature.  
Closes #16 
I tested the change by tapping on dismissible cards and making sure only the background dismissed them, not the card content view.  I also tested that all controls that were user tappable on the card still worked as expected, e.g. buttons.  

### Description
I have added a delegate to the tap gesture recogniser on **BulletinViewController** and then added the following delegate method to stop the gesture recogniser on the content view or subviews:

> gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool