### PR TITLE
Add `bulletinCardAppeared` completion handler

### DIFF
--- a/Example/Swift/ViewController.swift
+++ b/Example/Swift/ViewController.swift
@@ -140,6 +140,10 @@ class ViewController: UIViewController {
 //        bulletinManager.hidesHomeIndicator = true
 //        bulletinManager.backgroundColor = .blue
 
+//        bulletinManager.bulletinCardAppeared = { (item) in
+//            // Additional configuration once card appeared
+//        }
+
         bulletinManager.backgroundViewStyle = currentBackground.style
         bulletinManager.statusBarAppearance = shouldHideStatusBar ? .hidden : .automatic
         bulletinManager.prepareAndPresent(above: self)

--- a/Sources/BulletinManager.swift
+++ b/Sources/BulletinManager.swift
@@ -98,6 +98,11 @@ import UIKit
 
     @objc public var allowsSwipeInteraction: Bool = true
 
+    /**
+     * The code to be executed when bulletin card appeared.
+     */
+    
+    @objc public var bulletinCardAppeared: ((BulletinItem) -> Void)? = nil
 
     // MARK: - Private Properties
 
@@ -526,6 +531,8 @@ extension BulletinManager {
             }
 
             UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, newArrangedSubviews.first)
+
+            self.viewController.bulletinAppeared()
 
         }
 

--- a/Sources/Support/BulletinViewController.swift
+++ b/Sources/Support/BulletinViewController.swift
@@ -96,6 +96,14 @@ extension BulletinViewController {
 
     }
 
+    /// When the bulletin item appeared.
+    
+    public func bulletinAppeared() {
+        if let manager = manager, let bulletinCardAppeared = manager.bulletinCardAppeared {
+            bulletinCardAppeared(manager.currentItem)
+        }
+    }
+
     override func loadView() {
 
         super.loadView()


### PR DESCRIPTION
If users want to do additional setup when the bulletin card appeared on the screen (eg. become first responder to show up keyboard automatically)

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
I was trying to get the keyboard automatically shown up once the card appeared

### Description
This method will be called each time the card appeared on the screen and also each time when a new item is displayed