### PR TITLE
Add closure for complete bulletin board dismissal

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ Several styles are available in the `BulletinBackgroundViewStyle` enum:
 
 > Note: blurred backgrounds are available in iOS 10.0 and later.
 
+## Dismissal Closures
+
+You can set the `dismissalHandler` property of a bulletin item with a closure to be called on its dismissal. Additionally the `dismissalHandler` property of the `dismissalHandler` will be called when it is completely dismissed.
+
 ## Dismissal
 
 If you set the `isDismissable` property to `true`, the user will be able to dismiss the bulletin by tapping outside of the card or by swiping the card down.

--- a/Sources/BulletinManager.swift
+++ b/Sources/BulletinManager.swift
@@ -98,6 +98,12 @@ import UIKit
 
     @objc public var allowsSwipeInteraction: Bool = true
 
+    
+    /**
+     * A callback that will be called when the bulletin is completely dismissed.
+     *
+     */
+    public var dismissalHandler: (()->())?
 
     // MARK: - Private Properties
 
@@ -406,6 +412,7 @@ extension BulletinManager {
     @nonobjc func completeDismissal() {
 
         currentItem.dismissalHandler?(currentItem)
+        dismissalHandler?()
 
         for arrangedSubview in viewController.contentStackView.arrangedSubviews {
             viewController.contentStackView.removeArrangedSubview(arrangedSubview)


### PR DESCRIPTION
### Checklist
- [X] I've tested my changes.
- [X] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
We needed a callback that fired when the bulletin board was dismissed (as opposed to individual bulletin items). 

### Description
Very simple addition tagged on to existing 'completeDismissal' method.
- this is preferable (in our particular use case) over attaching the dismissal closure to the last bulletin itself 