### PR TITLE
fix bug in Swift Example

### DIFF
--- a/Example/Swift/ViewController.swift
+++ b/Example/Swift/ViewController.swift
@@ -140,6 +140,7 @@ class ViewController: UIViewController {
 //        bulletinManager.hidesHomeIndicator = true
 //        bulletinManager.backgroundColor = .blue
 
+        reloadManager()
         bulletinManager.backgroundViewStyle = currentBackground.style
         bulletinManager.statusBarAppearance = shouldHideStatusBar ? .hidden : .automatic
         bulletinManager.showBulletin(above: self)


### PR DESCRIPTION
<!-- Thanks for contributing to _BulletinBoard_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [ ] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
> I will read it later because I found the bug when I first launched the app.
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The Swift Example App will crash. 
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
Call reloadManager() when click `Show Intro` it will update the bulletin manger and thus the app would not crash. Please check it.
<!-- If you are submitting a link to your app for the README, you can omit this section. -->

### Description
<!--- Describe your changes in detail. -->
I found a bug in the Swift Example. Click the `Show Intro` first and swipe the dismiss the item, and then click `Show Intro` again, the Swift Example will crash for the item has no next item when you click the Configure button.