### PR TITLE
Adding the ability to use an NSAttributedString for bulletin text

### DIFF
--- a/Sources/Models/PageBulletinItem.swift
+++ b/Sources/Models/PageBulletinItem.swift
@@ -59,10 +59,18 @@ import UIKit
     /**
      * An description text to display below the image.
      *
-     * If you set this property to `nil`, no label will be displayed (this is the default).
+     * If you set this property to `nil`, no label will be displayed unless the `attributedDescriptionText` is set (this is the default).
      */
 
     @objc public var descriptionText: String?
+
+    /**
+     * An attributed description text to display below the image.
+     *
+     * If you set this property to `nil`, no label will be displayed unless the `descriptionText` is set (this is the default).
+     */
+
+    @objc public var attributedDescriptionText: NSAttributedString?
 
     // MARK: - Customization
 
@@ -191,7 +199,14 @@ import UIKit
 
         // Description Label
 
-        if let descriptionText = self.descriptionText {
+
+        if let attributedDescriptionText = self.attributedDescriptionText {
+
+            descriptionLabel = interfaceBuilder.makeDescriptionLabel()
+            descriptionLabel!.attributedText = attributedDescriptionText
+            contentViews.append(descriptionLabel!)
+
+        } else if let descriptionText = self.descriptionText {
 
             descriptionLabel = interfaceBuilder.makeDescriptionLabel()
             descriptionLabel!.text = descriptionText


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
This change allows for a myriad of ways to make bulletins look nicer. They can now have their own look and feel options for the text displayed. One improvement I am most pleased with is allowing for dynamic text support through NSAttributedString.

It closes issue #75 that I opened yesterday.

### Description
This change is minimal, but works more like how one would expect UILabel to handle text. UILabel defaults to using a supplied `NSAttributedString` if given, and a `String` otherwise. The same hierarchy is mimicked here.

Here is one example of how it looks, though given how flexible NSAttributedString is, you can create your own look and feel.

![nsattributedstring bulletinboard](https://user-images.githubusercontent.com/716513/40012502-e4199346-5778-11e8-82a5-80b68ddd42f5.png)

@alexaubry Please feel free to provide as much feedback as you'd like, and let me know if I missed anything.

Thanks!