### PR TITLE
Fix layout "jump" between cards during animation

### DIFF
--- a/Sources/Support/Views/ContinuousCorners/ContinuousMaskLayer.swift
+++ b/Sources/Support/Views/ContinuousCorners/ContinuousMaskLayer.swift
@@ -8,9 +8,21 @@
 
 import UIKit
 
-class ContinuousMaskLayer: CALayer {
+private class AnimatingShapeLayer: CAShapeLayer {
 
-    private let maskLayer = CAShapeLayer()
+    override func action(forKey event: String) -> CAAction? {
+
+        if event == "path" {
+            return CABasicAnimation(keyPath: event)
+        } else {
+            return super.action(forKey: event)
+        }
+
+    }
+
+}
+
+class ContinuousMaskLayer: CALayer {
 
     /// The corner radius.
     var continuousCornerRadius: CGFloat = 0 {
@@ -28,12 +40,11 @@ class ContinuousMaskLayer: CALayer {
 
     override init(layer: Any) {
         super.init(layer: layer)
-        self.mask = maskLayer
     }
 
     override init() {
         super.init()
-        self.mask = maskLayer
+        self.mask = AnimatingShapeLayer()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -47,10 +58,14 @@ class ContinuousMaskLayer: CALayer {
 
     private func refreshMask() {
 
+        guard let mask = mask as? CAShapeLayer else {
+            return
+        }
+
         let radii = CGSize(width: continuousCornerRadius, height: continuousCornerRadius)
         let roundedPath = UIBezierPath(roundedRect: bounds, byRoundingCorners: roundedCorners, cornerRadii: radii)
 
-        maskLayer.path = roundedPath.cgPath
+        mask.path = roundedPath.cgPath
 
     }
 

--- a/Sources/Support/Views/ContinuousCorners/ContinuousMaskLayer.swift
+++ b/Sources/Support/Views/ContinuousCorners/ContinuousMaskLayer.swift
@@ -10,12 +10,12 @@ import UIKit
 
 private class AnimatingShapeLayer: CAShapeLayer {
 
-    override func action(forKey event: String) -> CAAction? {
+    override class func defaultAction(forKey event: String) -> CAAction? {
 
         if event == "path" {
             return CABasicAnimation(keyPath: event)
         } else {
-            return super.action(forKey: event)
+            return super.defaultAction(forKey: event)
         }
 
     }


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
This solves issue #77.

### Description

In the end, this was not related to Auto Layout. The problem was that the shape layer's path was not updated through an animation, and therefore caused the jump we saw.
