### PR TITLE
Show Bulletin above whole Application

### DIFF
--- a/Sources/BLTNItemManager.swift
+++ b/Sources/BLTNItemManager.swift
@@ -106,6 +106,7 @@ import UIKit
     fileprivate let rootItem: BLTNItem
     fileprivate var itemsStack: [BLTNItem]
     fileprivate var previousItem: BLTNItem?
+    fileprivate var presentingWindow: UIWindow?
 
     fileprivate var isPrepared: Bool = false
     fileprivate var isPreparing: Bool = false
@@ -399,6 +400,27 @@ extension BLTNItemManager {
         presentingVC.present(bulletinController, animated: animated, completion: completion)
 
     }
+    
+    @objc(showBulletinInApplication:animated:completion:)
+    public func showBulletin(in application: UIApplication,
+                             animated: Bool = true,
+                             completion: (() -> Void)? = nil) {
+        
+        presentingWindow = UIWindow(frame: UIScreen.main.bounds)
+        presentingWindow?.rootViewController = UIViewController()
+        
+        // set alert window above current top window
+        if let topWindow = application.windows.last {
+            presentingWindow?.windowLevel = topWindow.windowLevel + 1
+        }
+        
+        presentingWindow?.makeKeyAndVisible()
+        
+        if let vc = presentingWindow?.rootViewController {
+            self.showBulletin(above: vc, animated: animated, completion: completion)
+        }
+        
+    }
 
     /**
      * Dismisses the bulletin and clears the current page. You will have to call `prepare` before
@@ -438,6 +460,9 @@ extension BLTNItemManager {
             bulletinController.contentStackView.removeArrangedSubview(arrangedSubview)
             arrangedSubview.removeFromSuperview()
         }
+        
+        presentingWindow?.isHidden = true
+        presentingWindow = nil
 
         bulletinController.backgroundView = nil
         bulletinController.manager = nil

--- a/Sources/BLTNItemManager.swift
+++ b/Sources/BLTNItemManager.swift
@@ -413,7 +413,7 @@ extension BLTNItemManager {
     public func showBulletin(in application: UIApplication,
                              animated: Bool = true,
                              completion: (() -> Void)? = nil) {
-        
+        assert(presentingWindow == nil, "Attempt to present a Bulletin on top of another Bulletin window. Make sure to dismiss any existing bulletin before calling this method.")
         presentingWindow = UIWindow(frame: UIScreen.main.bounds)
         presentingWindow?.rootViewController = UIViewController()
         

--- a/Sources/BLTNItemManager.swift
+++ b/Sources/BLTNItemManager.swift
@@ -401,6 +401,14 @@ extension BLTNItemManager {
 
     }
     
+    /**
+     * Presents the bulletin on top of your application window.
+     *
+     * - parameter application: The application in which to display the bulletin. (normally: UIApplication.shared)
+     * - parameter animated: Whether to animate presentation. Defaults to `true`.
+     * - parameter completion: An optional block to execute after presentation. Default to `nil`.
+     */
+    
     @objc(showBulletinInApplication:animated:completion:)
     public func showBulletin(in application: UIApplication,
                              animated: Bool = true,


### PR DESCRIPTION
<!-- Thanks for contributing to _BulletinBoard_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
<!-- If you are submitting a link to your app for the README, you can omit this section. -->

When showing a bulletin, it is required to know the view controller you want to present it on. In some cases, however, this is not known.
Also when the view controller underneath changes during presentation or if a UIAlertController is displayed already, the method of presenting the bulletin above a known view controller is impossible or very inconvenient. 

### Description
<!--- Describe your changes in detail. -->
I've added a second method to present the view controller, in which you don't have to specify a view controller. Instead of presenting on top of your specified view controller, it creates a new UIWindow on top of your current windows and presents the bulletin inside this new UIWindow. This guarantees that the bulletin is at the top whatever your application shows and that it is shown at all (no UIAlertController stopping it or whatever). 

The only unpleasant thing about my implementation is that it is necessary to pass UIApplication.shared. This is needed because frameworks can't access it themselves. 