### PR TITLE
Add `willDisplay` method to BLTNItem which is called before a bulletin item is shown.

### DIFF
--- a/Sources/BLTNItemManager.swift
+++ b/Sources/BLTNItemManager.swift
@@ -577,6 +577,10 @@ extension BLTNItemManager {
             }
 
         }
+        
+        displayNewItemsAnimationPhase.completionHandler = {
+            self.currentItem.willDisplay()
+        }
 
         let finalAnimationPhase = AnimationPhase(relativeDuration: 1/3, curve: .linear)
 

--- a/Sources/Models/BLTNActionItem.h
+++ b/Sources/Models/BLTNActionItem.h
@@ -263,6 +263,12 @@
  */
 
 - (void)tearDown;
+    
+/**
+* Called by the manager when bulletin item is about to be pushed onto the view.
+*/
+    
+- (void)willDisplay;
 
 /**
  * Called by the manager when bulletin item is pushed onto the view.

--- a/Sources/Models/BLTNActionItem.m
+++ b/Sources/Models/BLTNActionItem.m
@@ -152,6 +152,10 @@
     self.actionButton = nil;
     self.alternativeButton = nil;
 }
+    
+- (void)willDisplay
+{
+}
 
 - (void)onDisplay
 {

--- a/Sources/Models/BLTNItem.h
+++ b/Sources/Models/BLTNItem.h
@@ -105,6 +105,12 @@
  */
 
 - (void)tearDown;
+    
+/**
+* Called by the manager when bulletin item is about to be pushed onto the view.
+*/
+    
+- (void)willDisplay;
 
 /**
  * Called by the manager when bulletin item is pushed onto the view.


### PR DESCRIPTION
<!-- Thanks for contributing to _BulletinBoard_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
<!-- If you are submitting a link to your app for the README, you can omit this section. -->

I use mostly stack views to build my custom bulletin pages.
The problem is that many times, I want some views to be initially hidden and only show as a result of user action or some other conditions. 

Setting the `isHidden` property in views help the stack view know which views to show/hide but since the library recursively loops the views and sets the `isHidden` during transition in [refreshCurrentItemInterface()](https://github.com/alexaubry/BulletinBoard/blob/05b4f0e70c8b5564d9c00980318b11bfb38d0ec3/Sources/BLTNItemManager.swift#L504) method, the desired effect is lost and all views become visible at the end of the transition. 

I tried setting the desired value for `isHidden` property to the views in `onDisplay()` method but this is called after the bulletin item is shown hence views which should be hidden end up being visible for a short time.

### Description
<!--- Describe your changes in detail. -->

Solution: I added `willDisplay()` method which is called before the bulletin item is shown providing a chance to hide or show views correctly.
