### PR TITLE
Fix frozen dismissal after initial interaction

### DIFF
--- a/Sources/Support/Animations/BulletinSwipeInteractionController.swift
+++ b/Sources/Support/Animations/BulletinSwipeInteractionController.swift
@@ -147,11 +147,12 @@ class BulletinSwipeInteractionController: UIPercentDrivenInteractiveTransition, 
                 return
             }
 
+            isInteractionInProgress = false
+
             let translation = gestureRecognizer.translation(in: contentView).y
 
             if translation >= dismissThreshold {
                 isFinished = true
-                isInteractionInProgress = false
                 finish()
             } else {
                 resetCardViews()


### PR DESCRIPTION
### Checklist

- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context

Fixes #129 (UI Freezes after swiping bulletin and tapping close button)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
<!-- If you are submitting a link to your app for the README, you can omit this section. -->

### Description

This change marks the swipe interaction as `isInteractionInProgress == false` when the gesture ends. This prevents the interaction controller from being returned [here](https://github.com/alexaubry/BulletinBoard/blob/7086607d3476cea29cd77a65d13df5c8ed0da52e/Sources/Support/BulletinViewController.swift#L517-L527) for a non-interactive dismissal.