### PR TITLE
Fixed obsolete reference to InterfaceBuilderType

### DIFF
--- a/Sources/Models/BLTNActionItem.h
+++ b/Sources/Models/BLTNActionItem.h
@@ -30,7 +30,7 @@
  * (ex: haptic feedback).
  *
  * Use the `appearance` property to customize the appearance of the buttons. If you want to use a different interface
- * builder type, change the `InterfaceBuilderType` property.
+ * builder type, change the `interfaceBuilderType` property.
  */
 
 @interface BLTNActionItem : NSObject <BLTNItem>

--- a/Sources/Models/BLTNPageItem.h
+++ b/Sources/Models/BLTNPageItem.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  * implementations if you do.
  *
  * Use the `appearance` property to customize the appearance of the page. If you want to use a different interface
- * builder type, change the `InterfaceBuilderType` property.
+ * builder type, change the `interfaceBuilderType` property.
  */
 
 @interface BLTNPageItem : BLTNActionItem


### PR DESCRIPTION
<!-- Thanks for contributing to _BulletinBoard_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
<!-- If you are submitting a link to your app for the README, you can omit this section. -->
This changes an obsolete reference to InterfaceBuilderType, brought up by issue #104.

### Description
<!--- Describe your changes in detail. -->
Changes InterfaceBuilderType to interfaceBuilderType within comments of [BLTNActionItem.h](https://github.com/alexaubry/BulletinBoard/blob/80eca1334270a5f167b492d1821c6cbc416571f1/Sources/Models/BLTNActionItem.h#L32-L33) and [BLTNPageItem.h](https://github.com/alexaubry/BulletinBoard/blob/80eca1334270a5f167b492d1821c6cbc416571f1/Sources/Models/BLTNPageItem.h#L25-L26).