### PR TITLE
added popTo(item:orDismiss:)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,10 @@ The `BLTNItem` protocol exposes a `manager` property that is set when the item i
 
 You can use it to interact with the presented bulletin. Call:
 
+- `manager?.push(item:)` with a `BulletinItem` to present a new item
 - `manager?.popItem()` to go back to the previous item
 - `manager?.popToRootItem()` to go back to the first item
-- `manager?.push(item:)` with a `BulletinItem` to present a new item
+- `manager?.popTo(item:orDismiss:)` to go back to a specific item
 - `manager?.dismissBulletin(animated:)` to dismiss the bulletin
 - `manager?.displayNextItem()` to display the next item (see below)
 

--- a/Sources/BLTNItemManager.swift
+++ b/Sources/BLTNItemManager.swift
@@ -331,6 +331,40 @@ extension BLTNItemManager {
     }
 
     /**
+     * Removes items from the stack until a specific item is found.
+     * - parameter item: The item to seek.
+     * - parameter orDismiss: If true, dismiss bullein if not found. Otherwise popToRootItem()
+     */
+    
+    @objc public func popTo(item: BLTNItem, orDismiss: Bool) {
+        
+        assertIsPrepared()
+        assertIsMainThread()
+        
+        for index in 0..<itemsStack.count  {
+            
+            if itemsStack[index] === item {
+                
+                self.currentItem = itemsStack[index]
+                shouldDisplayActivityIndicator = currentItem.shouldStartWithActivityIndicator
+                refreshCurrentItemInterface()
+                
+                for removeIndex in (index+1..<itemsStack.count).reversed() {
+                    let removeItem = itemsStack.remove(at: removeIndex)
+                    tearDownItemsChain (startingAt: removeItem)
+                }
+                return
+            }
+        }
+        
+        if item !== rootItem, orDismiss {
+            dismissBulletin(animated: true)
+        } else {
+            popToRootItem()
+        }
+    }
+    
+    /**
      * Removes all the items from the stack and displays the root item.
      */
 


### PR DESCRIPTION
<!-- Thanks for contributing to _BulletinBoard_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
This is loosely related to my issue #103. It resolves a situation where a Page can be used either standalone or as part of a combined workflow. 
e.g. a pair of Pages used to Select an Album and Select an Image in an Album could be used:
AppUI -> Send Image -> SelectAlbumPage -> SelectImagePage -> action dismisses
vs
AppUI -> ViewAccountPage -> EditAccountPage -> Edit Avatar -> SelectAlbumPage -> SelectImagePage -> action should pop to EditAccountPage

A page constructor can be created that takes an optional "intermediate root": 

````
    @objc func cancelTapped(sender: UIButton) {
        if let myRoot = myRoot {
            self.manager?.popTo(item: myRoot, orDismiss: true)
        } else {
            self.manager?.dismissBulletin(animated: true)
        }
    }
````

### Description
Created new popTo(item:orDismiss:) method. It takes an item and searches the internal itemsStack for an exact match to the supplied item. If the item is found, it is set as current and redraw is triggered. Subsequent items on the stack are then torn down. 