### PR TITLE
Fix for iPad split view bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # _BulletinBoard_ Changelog
 
+## Unreleased
+### Fixes
+- Fix for iPad split view bug
+[#173] (https://github.com/alexaubry/BulletinBoard/pull/173)
+
 ## 🔖 v4.0.0
 ### Fixes
 - Upgrade to Swift 5

--- a/Sources/Support/Animations/BulletinDismissAnimationController.swift
+++ b/Sources/Support/Animations/BulletinDismissAnimationController.swift
@@ -42,7 +42,11 @@ class BulletinDismissAnimationController: NSObject, UIViewControllerAnimatedTran
         snapshotActivityIndicator.rightAnchor.constraint(equalTo: snapshot.rightAnchor).isActive = true
         snapshotActivityIndicator.bottomAnchor.constraint(equalTo: snapshot.bottomAnchor).isActive = true
 
-        snapshotActivityIndicator.style = .whiteLarge
+        if #available(iOSApplicationExtension 13.0, *) {
+            snapshotActivityIndicator.style = UIActivityIndicatorView.Style.large
+        } else {
+            snapshotActivityIndicator.style = .whiteLarge
+        }
         snapshotActivityIndicator.color = .black
         snapshotActivityIndicator.isUserInteractionEnabled = false
 

--- a/Sources/Support/Animations/BulletinDismissAnimationController.swift
+++ b/Sources/Support/Animations/BulletinDismissAnimationController.swift
@@ -42,7 +42,7 @@ class BulletinDismissAnimationController: NSObject, UIViewControllerAnimatedTran
         snapshotActivityIndicator.rightAnchor.constraint(equalTo: snapshot.rightAnchor).isActive = true
         snapshotActivityIndicator.bottomAnchor.constraint(equalTo: snapshot.bottomAnchor).isActive = true
 
-        if #available(iOSApplicationExtension 13.0, *) {
+        if #available(iOS 13.0, *) {
             snapshotActivityIndicator.style = UIActivityIndicatorView.Style.large
         } else {
             snapshotActivityIndicator.style = .whiteLarge

--- a/Sources/Support/Animations/BulletinPresentationAnimationController.swift
+++ b/Sources/Support/Animations/BulletinPresentationAnimationController.swift
@@ -31,6 +31,11 @@ class BulletinPresentationAnimationController: NSObject, UIViewControllerAnimate
             return
         }
 
+        // Fix the frame (Needed for iPad app running in split view)
+        if let fromFrame = transitionContext.viewController(forKey: .from)?.view.frame {
+            toVC.view.frame = fromFrame
+        }
+
         let rootView = toVC.view!
         let contentView = toVC.contentView
         let backgroundView = toVC.backgroundView!

--- a/Sources/Support/BulletinViewController.swift
+++ b/Sources/Support/BulletinViewController.swift
@@ -165,7 +165,7 @@ extension BulletinViewController {
         activityIndicator.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
         activityIndicator.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
 
-        if #available(iOSApplicationExtension 13.0, *) {
+        if #available(iOS 13.0, *) {
             activityIndicator.style = UIActivityIndicatorView.Style.large
         } else {
             activityIndicator.style = .whiteLarge

--- a/Sources/Support/BulletinViewController.swift
+++ b/Sources/Support/BulletinViewController.swift
@@ -165,7 +165,11 @@ extension BulletinViewController {
         activityIndicator.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
         activityIndicator.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
 
-        activityIndicator.style = .whiteLarge
+        if #available(iOSApplicationExtension 13.0, *) {
+            activityIndicator.style = UIActivityIndicatorView.Style.large
+        } else {
+            activityIndicator.style = .whiteLarge
+        }
         activityIndicator.color = .black
         activityIndicator.isUserInteractionEnabled = false
 


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
This fixes the issue #172 
Changes were tested with the example application provided.

### Description
Fix was done by setting the correct frame in the `BulletinPresentationAnimationController` when animating the view in. Also fixed couple activity indicator style deprecation warnings.