### PR TITLE
Fix the background view origin when presenting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # _BulletinBoard_ Changelog
 ## Unreleased
+### Fixes
+- Fix the background view origin when presenting
+[#183](https://github.com/alexaubry/BulletinBoard/pull/183)
 
 ## 🔖 v4.1.2
 ### Fixes

--- a/Sources/Support/Animations/BulletinPresentationAnimationController.swift
+++ b/Sources/Support/Animations/BulletinPresentationAnimationController.swift
@@ -31,15 +31,18 @@ class BulletinPresentationAnimationController: NSObject, UIViewControllerAnimate
             return
         }
 
+        let containerView = transitionContext.containerView
+
         // Fix the frame (Needed for iPad app running in split view)
-        if let fromFrame = transitionContext.viewController(forKey: .from)?.view.frame {
+        // (Convert the "from" view's frame coordinates to the container view's coordinate system)
+        if let fromView = transitionContext.viewController(forKey: .from)?.view {
+            let fromFrame = containerView.convert(fromView.frame, from: fromView)
             toVC.view.frame = fromFrame
         }
 
         let rootView = toVC.view!
         let contentView = toVC.contentView
         let backgroundView = toVC.backgroundView!
-        let containerView = transitionContext.containerView
 
         // Add root view
 


### PR DESCRIPTION
When presenting over a ViewController (the “from” VC), if that ViewController is not at the screen’s origin, the background view will not appear at the correct position above it.

This fixes the problem by setting the background view’s frame to the “from” VC’s view’s frame **converted into the coordinate system of the container view.**

<!-- Thanks for contributing to _BulletinBoard_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
The issue this fixes is described in Issue #181 .

Before this fix, the frame of the presenting VC's View is being applied to the background view during the transition animation. However, the frame of the presenting VC's View is always going to have an origin of `(x: 0, y: 0)` in it's own coordinate system.

If the presenting VC is not actually at the origin of the screen (which will also be the origin of the transition's containerView), then the background will be the same size as the presenting VC but located at the origin, not correctly aligned with the presenting VC.

I've tested this inside a project in a couple of different presenting VC scenarios. 

If the old behavior is preferred by the maintainers, no problem. Thanks for sharing this useful library.

### Description
This PR fixes that problem by converting the frame into the containerView's coordinate system before applying it to the background view.

Mostly just this: `let fromFrame = containerView.convert(fromView.frame, from: fromView)`