### PR TITLE
Fix broken links to the documentation

### DIFF
--- a/.generate-docs.sh
+++ b/.generate-docs.sh
@@ -9,7 +9,7 @@ AUTHOR_URL="https://twitter.com/_alexaubry"
 MODULE_NAME="BLTNBoard"
 COPYRIGHT="Copyright © 2017 - present $AUTHOR. Available under the MIT License."
 GITHUB_URL="https://github.com/alexaubry/BulletinBoard"
-GH_PAGES_URL="https://alexaubry.github.io/BulletinBoard"
+GH_PAGES_URL="https://alexisakers.github.io/BulletinBoard"
 
 bundle exec jazzy \
     --swift-version $SWIFT_VERSION \
@@ -21,7 +21,7 @@ bundle exec jazzy \
     -g "$GITHUB_URL" \
     --github-file-prefix "$GITHUB_URL/tree/master" \
     -r "$GH_PAGES_URL" \
-    -o "$OUTPUT"\
+    -o "$OUTPUT" \
     --min-acl public \
     --use-safe-filenames \
     --exclude="Sources/Support/*.swift" \

--- a/BulletinBoard.podspec
+++ b/BulletinBoard.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files  = "Sources/**/*"
   s.private_header_files = "Sources/Support/**/*.h"
   s.frameworks  = "UIKit"
-  s.documentation_url = "https://alexaubry.github.io/BulletinBoard"
+  s.documentation_url = "https://alexisakers.github.io/BulletinBoard"
   s.module_name = "BLTNBoard"
   s.swift_version = "5.0"
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ The following is a set of guidelines for contributing to _BulletinBoard_ on GitH
 
 Before submitting a new GitHub issue, please make sure to
 
-- Check out the [documentation](https://alexaubry.github.io/BulletinBoard).
+- Check out the [documentation](https://alexisakers.github.io/BulletinBoard).
 - Read the usage guide on [the README](https://github.com/alexaubry/BulletinBoard/#usage).
 - Search for [existing GitHub issues](https://github.com/alexaubry/BulletinBoard/issues).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Version](https://img.shields.io/cocoapods/v/BulletinBoard.svg?style=flat)](https://cocoapods.org/pods/BulletinBoard)
 [![License](https://img.shields.io/cocoapods/l/BulletinBoard.svg?style=flat)](https://cocoapods.org/pods/BulletinBoard)
 [![Platform](https://img.shields.io/cocoapods/p/BulletinBoard.svg?style=flat)](https://cocoapods.org/pods/BulletinBoard)
-[![Documentation](https://img.shields.io/badge/Documentation-available-blue.svg)](https://alexaubry.github.io/BulletinBoard)
+[![Documentation](https://img.shields.io/badge/Documentation-available-blue.svg)](https://alexisakers.github.io/BulletinBoard)
 [![Contact: @_alexaubry](https://raw.githubusercontent.com/alexaubry/BulletinBoard/main/.assets/twitter_badge.svg?sanitize=true)](https://twitter.com/_alexaubry)
 
 BulletinBoard is an iOS library that generates and manages contextual cards displayed at the bottom of the screen. It is especially well suited for quick user interactions such as onboarding screens or configuration.
@@ -66,8 +66,8 @@ github "alexaubry/BulletinBoard"
 
 ## Documentation
 
-- The full library documentation is available [here](https://alexaubry.github.io/BulletinBoard).
-- To learn how to start using `BulletinBoard`, check out our [Getting Started](https://alexaubry.github.io/BulletinBoard/getting-started.html) guide.
+- The full library documentation is available [here](https://alexisakers.github.io/BulletinBoard).
+- To learn how to start using `BulletinBoard`, check out our [Getting Started](https://alexisakers.github.io/BulletinBoard/getting-started.html) guide.
 
 ## Contributing
 


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context

Links to the documentation is broken.

### Description

This PR replaces "alexaubry.github.io" with "alexisakers.github.io".