### PR TITLE
Replace with UserNotifications framework

### DIFF
--- a/Example/ObjC/Supporting Files/PermissionsManager.m
+++ b/Example/ObjC/Supporting Files/PermissionsManager.m
@@ -3,6 +3,7 @@
  *  Copyright (c) 2017 - present Alexis Aubry. Licensed under the MIT license.
  */
 
+#import <UserNotifications/UserNotifications.h>
 #import "PermissionsManager.h"
 
 @interface PermissionsManager ()
@@ -36,9 +37,10 @@
 
 -(void)requestLocalNotifications
 {
-    UIUserNotificationSettings* settings = [UIUserNotificationSettings settingsForTypes:(UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound) categories:NULL];
-
-    [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+    UNAuthorizationOptions options = UNAuthorizationOptionAlert | UNAuthorizationOptionBadge | UNAuthorizationOptionSound;
+    [UNUserNotificationCenter.currentNotificationCenter requestAuthorizationWithOptions:options completionHandler:^(BOOL granted, NSError * _Nullable error) {
+        // no-op
+    }];
 }
 
 -(void)requestWhenInUseLocation


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context

Getting warnings related UIUserNotification API when building the Objective-C example:
- 'UIUserNotificationSettings' is deprecated: first deprecated in iOS 10.0 - Use UserNotifications Framework's UNNotificationSettings
- 'UIUserNotificationTypeAlert' is deprecated: first deprecated in iOS 10.0 - Use UserNotifications Framework's UNAuthorizationOptions
- 'registerUserNotificationSettings:' is deprecated: first deprecated in iOS 10.0 - Use UserNotifications Framework's -[UNUserNotificationCenter requestAuthorizationWithOptions:completionHandler:] and -[UNUserNotificationCenter setNotificationCategories:]

### Description

This PR replaces UIUserNotification API with UserNotifications framework.