### PR TITLE
Finish issue #128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Fixes
 - Fix the background view origin when presenting
 [#183](https://github.com/alexaubry/BulletinBoard/pull/183)
+-Fix the ability to change alignment for title, description and image
+[#128](https://github.com/alexisakers/BulletinBoard/pull/200)
+
 
 ## 🔖 v4.1.2
 ### Fixes

--- a/Example/Swift/Bulletin/BulletinDataSource.swift
+++ b/Example/Swift/Bulletin/BulletinDataSource.swift
@@ -30,6 +30,11 @@ enum BulletinDataSource {
     static func makeIntroPage() -> FeedbackPageBLTNItem {
 
         let page = FeedbackPageBLTNItem(title: "Welcome to\nPetBoard")
+        
+        page.titleAlignment = .right
+        page.descriptionAlignment = .right
+        page.imageContentMode = .right
+        
         page.image = #imageLiteral(resourceName: "RoundedIcon")
         page.imageAccessibilityLabel = "😻"
         page.appearance = makeLightAppearance()

--- a/Sources/InterfaceBuilder/BLTNInterfaceBuilder.swift
+++ b/Sources/InterfaceBuilder/BLTNInterfaceBuilder.swift
@@ -24,11 +24,11 @@ import UIKit
      * Creates a standard title label.
      */
 
-    @objc(makeTitleLabelNextToCloseButton:)
-    open func makeTitleLabel(isNextToCloseButton: Bool) -> BLTNTitleLabelContainer {
+    @objc(makeTitleLabelNextToCloseButton:titleAlginment:)
+    open func makeTitleLabel(isNextToCloseButton: Bool, titleAlginment:  NSTextAlignment) -> BLTNTitleLabelContainer {
 
         let titleLabel = UILabel()
-        titleLabel.textAlignment = .center
+        titleLabel.textAlignment = titleAlginment
         titleLabel.textColor = appearance.titleTextColor
         titleLabel.accessibilityTraits.insert(.header)
         titleLabel.numberOfLines = 2
@@ -45,10 +45,10 @@ import UIKit
      * Creates a standard description label.
      */
 
-    @objc open func makeDescriptionLabel() -> UILabel {
+    @objc open func makeDescriptionLabel(descriptionAlginment: NSTextAlignment) -> UILabel {
 
         let descriptionLabel = UILabel()
-        descriptionLabel.textAlignment = .center
+        descriptionLabel.textAlignment = descriptionAlginment
         descriptionLabel.textColor = appearance.descriptionTextColor
         descriptionLabel.numberOfLines = 0
         descriptionLabel.font = appearance.makeDescriptionFont()

--- a/Sources/Models/BLTNPageItem.swift
+++ b/Sources/Models/BLTNPageItem.swift
@@ -26,6 +26,11 @@ import UIKit
 
     /// The title of the page.
     @objc public let title: String
+    
+    /// The alignments of the title and description
+    public var titleAlignment: NSTextAlignment = .center
+    public var descriptionAlignment: NSTextAlignment = .center
+    public var imageContentMode: UIView.ContentMode = .scaleAspectFit
 
     /**
      * An image to display below the title.
@@ -179,7 +184,7 @@ import UIKit
         
         // Title
         let isNextToCloseButton = isDismissable && requiresCloseButton
-        let titleView = interfaceBuilder.makeTitleLabel(isNextToCloseButton: isNextToCloseButton)
+        let titleView = interfaceBuilder.makeTitleLabel(isNextToCloseButton: isNextToCloseButton, titleAlginment: titleAlignment)
         titleView.label.text = title
         
         self.titleLabel = titleView
@@ -189,7 +194,8 @@ import UIKit
         // Image View
         if let image = self.image {
             let imageView = UIImageView(image: image)
-            imageView.contentMode = .scaleAspectFit
+            imageView.contentMode = imageContentMode
+//            imageView.contentMode = .scaleAspectFit
             imageView.tintColor = appearance.imageViewTintColor
             
             if let accessibilityLabel = imageAccessibilityLabel {
@@ -206,13 +212,13 @@ import UIKit
         
         // Description Label
         if let attributedDescription = attributedDescriptionText {
-            let label = interfaceBuilder.makeDescriptionLabel()
+            let label = interfaceBuilder.makeDescriptionLabel(descriptionAlginment: descriptionAlignment)
             label.attributedText = attributedDescription
             contentViews.append(label)
             self.descriptionLabel = label
             insertComplementaryViews(makeViewsUnderDescription)
         } else if let description = descriptionText {
-            let label = interfaceBuilder.makeDescriptionLabel()
+            let label = interfaceBuilder.makeDescriptionLabel(descriptionAlginment: descriptionAlignment)
             label.text = description
             contentViews.append(label)
             self.descriptionLabel = label


### PR DESCRIPTION
<!-- Thanks for contributing to _BulletinBoard_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](https://github.com/alexaubry/BulletinBoard/blob/master/CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
This is a Pull Request to fix issue [#128](https://github.com/alexisakers/BulletinBoard/issues/128). Someone requested that you could change the alignments of the title text, description text as well as the image. 

This PR solves that problem.

I tested on Xcode's 12.4 simulators of iPhone 8 and iPhone 12
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
<!-- If you are submitting a link to your app for the README, you can omit this section. -->

### Description
<!--- Describe your changes in detail. -->

To change the alignment of title when instantiating a page FeedbackPageBLTNItem() set the page's .titleAlignment to be whatever you want (.left, .right, ect). If a user does not specify then the default alignment is center.

Similarly, to change the alignment of description use the .descriptionAlignment to set to desirable alignment
And also to change the alignment of image use the .imageContentMode to set to desirable alignment 